### PR TITLE
Fix DEV mode on Safari when view transitioning to client:only compone…

### DIFF
--- a/.changeset/eighty-ladybugs-shake.md
+++ b/.changeset/eighty-ladybugs-shake.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes an error in dev mode on Safari where view transitions prevented navigating to pages with `client:only` components

--- a/packages/astro/src/transitions/router.ts
+++ b/packages/astro/src/transitions/router.ts
@@ -529,9 +529,8 @@ async function prepareForClientOnlyComponents(newDocument: Document, toLocation:
 	if (newDocument.body.querySelector(`astro-island[client='only']`)) {
 		// Load the next page with an empty module loader cache
 		const nextPage = document.createElement('iframe');
-		// do not fetch the file from the server, but use the current newDocument
-		nextPage.srcdoc =
-			(newDocument.doctype ? '<!DOCTYPE html>' : '') + newDocument.documentElement.outerHTML;
+		// with srcdoc resolving imports does not work on webkit browsers
+		nextPage.src = toLocation.href;
 		nextPage.style.display = 'none';
 		document.body.append(nextPage);
 		// silence the iframe's console


### PR DESCRIPTION
…nts (#9000)

* Fix DEV mode on Safari when view transitioning to client:only components

* Update .changeset/eighty-ladybugs-shake.md



---------

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
