### PR TITLE
Add autocomplete to button JSX type (#9522)

### DIFF
--- a/.changeset/beige-zebras-ring.md
+++ b/.changeset/beige-zebras-ring.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Add support for autocomplete attribute to the HTML button type.

--- a/packages/astro/astro-jsx.d.ts
+++ b/packages/astro/astro-jsx.d.ts
@@ -627,6 +627,7 @@ declare namespace astroHTML.JSX {
 	}
 
 	interface ButtonHTMLAttributes extends HTMLAttributes {
+		autocomplete?: string | undefined | null;
 		disabled?: boolean | string | undefined | null;
 		form?: string | undefined | null;
 		formaction?: string | undefined | null;


### PR DESCRIPTION
* Add autocomplete to button JSX type

This is “nonstandard and Firefox-specific” but often required when working with dynamic disabled state.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#autocomplete

* Run `pnpm exec changeset`

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
