### PR TITLE
fix(audit): remove false positive warnings on elements with `tabpanel…

### DIFF
--- a/.changeset/calm-beans-jam.md
+++ b/.changeset/calm-beans-jam.md
@@ -1,0 +1,5 @@
+---
+'astro': patch
+---
+
+Fixes false positive audit warnings on elements with the role "tabpanel".

--- a/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
+++ b/packages/astro/src/runtime/client/dev-toolbar/apps/audit/rules/a11y.ts
@@ -101,6 +101,7 @@ const aria_non_interactive_roles = [
 	'rowheader',
 	'search',
 	'status',
+	'tabpanel',
 	'term',
 	'timer',
 	'toolbar',
@@ -503,7 +504,7 @@ export const a11y: AuditRuleWithSelector[] = [
 		description:
 			'The `tabindex` attribute should only be used on interactive elements, as it can be confusing for keyboard-only users to navigate through non-interactive elements. If your element is only conditionally interactive, consider using `tabindex="-1"` to make it focusable only when it is actually interactive.',
 		message: (element) => `${element.localName} elements should not have \`tabindex\` attribute`,
-		selector: '[tabindex]',
+		selector: '[tabindex]:not([role="tabpanel"])',
 		match(element) {
 			// Scrollable elements are considered interactive
 			// See: https://www.w3.org/WAI/standards-guidelines/act/rules/0ssw9k/proposed/


### PR DESCRIPTION
…` role (#11459)

* fix(audit): add `tabpanel` to `aria_non_interactive_roles`

* fix(audit): allow `tabIndex` on elements with `tabpanel` role

See: https://github.com/infofarmer/eslint-plugin-jsx-a11y/blob/d32a27fb64f4127d31e4e76bd08e319cfaf0ba53/docs/rules/no-noninteractive-tabindex.md#rule-options

* chore: add changeset

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
